### PR TITLE
Fix create-dmg command in GitHub Actions workflow

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -82,7 +82,6 @@ jobs:
         # Create DMG
         create-dmg \
           --volname "MP3ToAudiobook" \
-          --volicon "MP3ToAudiobook.app" \
           --window-pos 200 120 \
           --window-size 800 400 \
           --icon-size 100 \


### PR DESCRIPTION
- Remove --volicon parameter that was causing build failure
- create-dmg was trying to copy app directory as volume icon file
- Now DMG creation should work properly